### PR TITLE
Removed hardcoded path

### DIFF
--- a/src/ImageResizer.Plugins.EPiFocalPoint/ClientResources/focalpoint/Editor.js
+++ b/src/ImageResizer.Plugins.EPiFocalPoint/ClientResources/focalpoint/Editor.js
@@ -2,7 +2,7 @@
     "epi/epi", "epi/shell/widget/_ValueRequiredMixin", "epi-cms/_ContentContextMixin", "epi/i18n!epi/cms/nls/focalpoint", "xstyle/css!./WidgetTemplate.css"],
 function (on, declare, aspect, registry, WidgetSet, _Widget, _TemplatedMixin, _WidgetsInTemplateMixin, epi, _ValueRequiredMixin, _ContentContextMixin, resources) {
 	return declare([_Widget, _TemplatedMixin, _WidgetsInTemplateMixin, _ValueRequiredMixin, _ContentContextMixin], {
-		templateString: dojo.cache("focal-point.focalpoint", "WidgetTemplate.html"),
+		templateString: dojo.cache("focal-point", "WidgetTemplate.html"),
 		imageUrl: null,
 		intermediateChanges: true,
 		resources: resources,

--- a/src/ImageResizer.Plugins.EPiFocalPoint/FocalPointEditorDescriptor.cs
+++ b/src/ImageResizer.Plugins.EPiFocalPoint/FocalPointEditorDescriptor.cs
@@ -6,7 +6,7 @@ namespace ImageResizer.Plugins.EPiFocalPoint {
 	[EditorDescriptorRegistration(TargetType = typeof(FocalPoint))]
 	public class FocalPointEditorDescriptor : EditorDescriptor {
 		public FocalPointEditorDescriptor() {
-			ClientEditingClass = "focal-point/focalpoint/editor";
+			ClientEditingClass = "focal-point/editor";
 		}
 	}
 }

--- a/src/ImageResizer.Plugins.EPiFocalPoint/module.config.transform
+++ b/src/ImageResizer.Plugins.EPiFocalPoint/module.config.transform
@@ -2,7 +2,7 @@
 <module xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
   <dojo>
     <paths>
-      <add name="focal-point" path="" />
+      <add name="focal-point" path="focalpoint" />
     </paths>
   </dojo>
 </module>


### PR DESCRIPTION
Hardcoded path and leaving module.config path empty caused episerver to add a trailing slash to ClientResources files.