### PR TITLE
ArgumentException in ImageDimensionService with progressive JPGs 

### DIFF
--- a/src/ImageResizer.Plugins.EPiFocalPoint/EPiFocalPointPlugin.cs
+++ b/src/ImageResizer.Plugins.EPiFocalPoint/EPiFocalPointPlugin.cs
@@ -133,9 +133,6 @@ namespace ImageResizer.Plugins.EPiFocalPoint {
 			if(resizeSettings.Mode == FitMode.Max) { // If using fitmode Max, the image won't be cropped, only resized, and focal point serves no purpose.
 				return false;
 			}
-			if(resizeSettings.Width < 0 && resizeSettings.Height < 0) {
-				return false;
-			}
 			var targetWidthIsLargerThanOriginal = resizeSettings.Width >= (focalPointData.OriginalWidth ?? 1);
 			var targetHeightIsLargerThanOriginal = resizeSettings.Height >= (focalPointData.OriginalHeight ?? 1);
 			if(targetWidthIsLargerThanOriginal && targetHeightIsLargerThanOriginal) { // If the target is bigger in both dimensions, it will result in a scaling operation, and the focal point serves no purpose.
@@ -148,16 +145,12 @@ namespace ImageResizer.Plugins.EPiFocalPoint {
 			var sourceHeight = focalPointData.OriginalHeight ?? 1;
 			var focalPointY = (int)Math.Round(sourceHeight * (focalPointData.FocalPoint.Y / 100));
 			var focalPointX = (int)Math.Round(sourceWidth * (focalPointData.FocalPoint.X / 100));
-			var sourceAspectRatio = (double)sourceWidth / sourceHeight;
 			double targetAspectRatio = 1.0f;
 			if(resizeSettings != null) {
 				//Calculate target aspect ratio from resizeSettings.
-				if (resizeSettings.Width > 0 && resizeSettings.Height > 0) {
-					targetAspectRatio = (double) resizeSettings.Width / resizeSettings.Height;
-				} else {
-					targetAspectRatio = sourceAspectRatio;
-				}<
+				targetAspectRatio = (double)resizeSettings.Width / resizeSettings.Height;
 			}
+			var sourceAspectRatio = (double)sourceWidth / sourceHeight;
 			var x1 = 0;
 			var y1 = 0;
 			int x2;

--- a/src/ImageResizer.Plugins.EPiFocalPoint/EPiFocalPointPlugin.cs
+++ b/src/ImageResizer.Plugins.EPiFocalPoint/EPiFocalPointPlugin.cs
@@ -133,6 +133,9 @@ namespace ImageResizer.Plugins.EPiFocalPoint {
 			if(resizeSettings.Mode == FitMode.Max) { // If using fitmode Max, the image won't be cropped, only resized, and focal point serves no purpose.
 				return false;
 			}
+			if(resizeSettings.Width < 0 && resizeSettings.Height < 0) {
+				return false;
+			}
 			var targetWidthIsLargerThanOriginal = resizeSettings.Width >= (focalPointData.OriginalWidth ?? 1);
 			var targetHeightIsLargerThanOriginal = resizeSettings.Height >= (focalPointData.OriginalHeight ?? 1);
 			if(targetWidthIsLargerThanOriginal && targetHeightIsLargerThanOriginal) { // If the target is bigger in both dimensions, it will result in a scaling operation, and the focal point serves no purpose.
@@ -145,12 +148,16 @@ namespace ImageResizer.Plugins.EPiFocalPoint {
 			var sourceHeight = focalPointData.OriginalHeight ?? 1;
 			var focalPointY = (int)Math.Round(sourceHeight * (focalPointData.FocalPoint.Y / 100));
 			var focalPointX = (int)Math.Round(sourceWidth * (focalPointData.FocalPoint.X / 100));
+			var sourceAspectRatio = (double)sourceWidth / sourceHeight;
 			double targetAspectRatio = 1.0f;
 			if(resizeSettings != null) {
 				//Calculate target aspect ratio from resizeSettings.
-				targetAspectRatio = (double)resizeSettings.Width / resizeSettings.Height;
+				if (resizeSettings.Width > 0 && resizeSettings.Height > 0) {
+					targetAspectRatio = (double) resizeSettings.Width / resizeSettings.Height;
+				} else {
+					targetAspectRatio = sourceAspectRatio;
+				}
 			}
-			var sourceAspectRatio = (double)sourceWidth / sourceHeight;
 			var x1 = 0;
 			var y1 = 0;
 			int x2;

--- a/src/ImageResizer.Plugins.EPiFocalPoint/EPiFocalPointPlugin.cs
+++ b/src/ImageResizer.Plugins.EPiFocalPoint/EPiFocalPointPlugin.cs
@@ -133,6 +133,9 @@ namespace ImageResizer.Plugins.EPiFocalPoint {
 			if(resizeSettings.Mode == FitMode.Max) { // If using fitmode Max, the image won't be cropped, only resized, and focal point serves no purpose.
 				return false;
 			}
+			if(resizeSettings.Width < 0 && resizeSettings.Height < 0) {
+				return false;
+			}
 			var targetWidthIsLargerThanOriginal = resizeSettings.Width >= (focalPointData.OriginalWidth ?? 1);
 			var targetHeightIsLargerThanOriginal = resizeSettings.Height >= (focalPointData.OriginalHeight ?? 1);
 			if(targetWidthIsLargerThanOriginal && targetHeightIsLargerThanOriginal) { // If the target is bigger in both dimensions, it will result in a scaling operation, and the focal point serves no purpose.
@@ -145,12 +148,16 @@ namespace ImageResizer.Plugins.EPiFocalPoint {
 			var sourceHeight = focalPointData.OriginalHeight ?? 1;
 			var focalPointY = (int)Math.Round(sourceHeight * (focalPointData.FocalPoint.Y / 100));
 			var focalPointX = (int)Math.Round(sourceWidth * (focalPointData.FocalPoint.X / 100));
+			var sourceAspectRatio = (double)sourceWidth / sourceHeight;
 			double targetAspectRatio = 1.0f;
 			if(resizeSettings != null) {
 				//Calculate target aspect ratio from resizeSettings.
-				targetAspectRatio = (double)resizeSettings.Width / resizeSettings.Height;
+				if (resizeSettings.Width > 0 && resizeSettings.Height > 0) {
+					targetAspectRatio = (double) resizeSettings.Width / resizeSettings.Height;
+				} else {
+					targetAspectRatio = sourceAspectRatio;
+				}<
 			}
-			var sourceAspectRatio = (double)sourceWidth / sourceHeight;
 			var x1 = 0;
 			var y1 = 0;
 			int x2;

--- a/src/ImageResizer.Plugins.EPiFocalPoint/Internal/Services/ImageDimensionService.cs
+++ b/src/ImageResizer.Plugins.EPiFocalPoint/Internal/Services/ImageDimensionService.cs
@@ -113,7 +113,6 @@ namespace ImageResizer.Plugins.EPiFocalPoint.Internal.Services {
 					binaryReader.ReadBytes(chunkLength - 2);
 				}
 			}
-			throw new ArgumentException(ErrorMessage);
 			return Size.Empty;
 		}
 	}

--- a/src/ImageResizer.Plugins.EPiFocalPoint/Internal/Services/ImageDimensionService.cs
+++ b/src/ImageResizer.Plugins.EPiFocalPoint/Internal/Services/ImageDimensionService.cs
@@ -11,7 +11,6 @@ namespace ImageResizer.Plugins.EPiFocalPoint.Internal.Services {
 		private static readonly ISize Invalid = new InvalidSize();
 		private static readonly ILogger Logger = LogManager.GetLogger();
 
-		private const string ErrorMessage = "Could not recognize image format.";
 		private static readonly Dictionary<byte[], Func<BinaryReader, Size>> ImageFormatDecoders = new Dictionary
 			<byte[], Func<BinaryReader, Size>>()
 			{
@@ -30,7 +29,8 @@ namespace ImageResizer.Plugins.EPiFocalPoint.Internal.Services {
 					try {
 						var size = GetDimensions(binaryReader);
 						if(size == Size.Empty) {
-							using(var image = Image.FromStream(stream, false, false)) {
+							stream.Position = 0;
+							using (var image = Image.FromStream(stream, false, false)) {
 								size = image.Size;
 							}
 						}
@@ -100,7 +100,7 @@ namespace ImageResizer.Plugins.EPiFocalPoint.Internal.Services {
 			while(binaryReader.ReadByte() == 0xff) {
 				var marker = binaryReader.ReadByte();
 				var chunkLength = ReadLittleEndianInt16(binaryReader);
-				if(marker == 0xc0) {
+				if(marker == 0xc0 || marker == 0xc2) {
 					binaryReader.ReadByte();
 					int height = ReadLittleEndianInt16(binaryReader);
 					int width = ReadLittleEndianInt16(binaryReader);
@@ -114,6 +114,7 @@ namespace ImageResizer.Plugins.EPiFocalPoint.Internal.Services {
 				}
 			}
 			throw new ArgumentException(ErrorMessage);
+			return Size.Empty;
 		}
 	}
 }


### PR DESCRIPTION
Hi,

we are getting ArgumentExceptions in the ImageDimensionService when using progressive JPGs. In DecodeJfif you are looking for a 0xc0 marker which is only valid for baseline jpgs. For progressive jpgs it should be 0xc2.

Additionally I would suggest that you replace the throw new ArgumentException(ErrorMessage); with return Size.Empty; so the fallback Image.FromStream can be used.
Keep in mind that you need to reset the stream position to the beginning (stream.Position = 0;) right before the Image.FromStream because the BinaryReader has already read some bytes.

Regards,
Benjamin